### PR TITLE
switch to question mark

### DIFF
--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -17,7 +17,10 @@
               <!-- {{ open ? 'assignment_returned' : item.fulfilled ? 'assignment_turned_in' : 'assignment' }} -->
             </v-icon>
             <v-icon v-else :style = "fulfilledIcon(item)">
-              {{ item['plain-string'] ? item.fulfilled ? "star" : "help_outline": item.fulfilled ? "check_box" : "check_box_outline_blank"}}
+              {{ item['plain-string']
+                  ? item.fulfilled ? "star" : "help_outline"
+                  : item.fulfilled ? "check_box" : "check_box_outline_blank"
+              }}
             </v-icon>
           </template>
           <span>{{item.percent_fulfilled}}%</span>

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -17,7 +17,7 @@
               <!-- {{ open ? 'assignment_returned' : item.fulfilled ? 'assignment_turned_in' : 'assignment' }} -->
             </v-icon>
             <v-icon v-else :style = "fulfilledIcon(item)">
-              {{ item['plain-string'] ? item.fulfilled ? "star" : "star_outline": item.fulfilled ? "check_box" : "check_box_outline_blank"}}
+              {{ item['plain-string'] ? item.fulfilled ? "star" : "help_outline": item.fulfilled ? "check_box" : "check_box_outline_blank"}}
             </v-icon>
           </template>
           <span>{{item.percent_fulfilled}}%</span>


### PR DESCRIPTION
The star icon for things we aren't sure what they are is misleading I think. I replaced it with a question mark to hopefully indicate that we don't know, but this isn't a super satisfactory solution because these requirements will prevent the audit from saying you're good even if you fulfill them. A deep solution is probably not in the scope of MVP, but I want your input @wishdasher in particular (and anyone else) on what we should do about this. I think this PR is the minimum, but if it's urgent we can add more.