### PR TITLE
Complete card styling fixes

### DIFF
--- a/src/components/ClassInfo.vue
+++ b/src/components/ClassInfo.vue
@@ -80,7 +80,11 @@
                 </tr>
                 <tr v-if = "currentSubject.rating !== undefined">
                   <td><b>Average Rating</b></td>
-                  <td>{{currentSubject.rating}}</td>
+                  <td>
+                    <a target="_blank" :href="'https://sisapp.mit.edu/ose-rpt/subjectEvaluationSearch.htm?search=Search&subjectCode='+currentSubject.subject_id">
+                      {{currentSubject.rating}}
+                    </a>
+                  </td>
                 </tr>
                 <tr v-if = "currentSubject.in_class_hours !== undefined || currentSubject.out_of_class_hours !== undefined">
                   <td><b>Hours</b></td>

--- a/src/components/ClassInfo.vue
+++ b/src/components/ClassInfo.vue
@@ -1,7 +1,7 @@
 <template>
     <v-layout>
       <v-flex>
-        <v-card class = "class-info-card" id = "classInfoCard" style = "display: flex; flex-direction:column;" >
+        <v-card class = "class-info-card" id = "classInfoCard" style = "display: flex; flex-direction:column;" width="40%" height="40%">
           <v-card-title :class = "['card-header',courseColor(currentSubject.subject_id)]">
             <v-flex style = "display: flex; flex-direction: row; align-items: center;">
               <div style = "padding: 0; margin: 0; display: block;">
@@ -327,30 +327,28 @@ export default {
       rList.topLevel = true;
       return rList;
     },
-    adjustCardStyle: function() {
-      var classInfoCard = $("#classInfoCard");
-      var searchInput = $("#searchInputTF");
-      var cardWidth = searchInput.outerWidth();
-      var cardLeft = cardWidth + searchInput.offset().left;
-      var browserWidth = $(window).width();
-      classInfoCard.css({right: browserWidth - cardLeft, width: cardWidth});
-    },
     addClass: function() {
       this.$emit('add-class',this.currentSubject);
     },
     cancelAddClass: function() {
       this.$emit('cancel-add-class');
     }
-  },
-  mounted() {
-    this.adjustCardStyle();
-    $(window).resize(this.adjustCardStyle);
   }
 }
 </script>
 
 
 <style>
+#classInfoCard {
+  right: 24px;
+}
+
+@media only screen and (max-width:959px) {
+  #classInfoCard {
+    right: 16px;
+  }
+}
+
 .card-header {
   padding: 0.5em 1em;
   display: inline-block;

--- a/src/components/ClassInfo.vue
+++ b/src/components/ClassInfo.vue
@@ -1,7 +1,7 @@
 <template>
     <v-layout>
       <v-flex>
-        <v-card class = "class-info-card" id = "classInfoCard" style = "display: flex; flex-direction:column;" width="40%" height="40%">
+        <v-card class = "class-info-card" id = "classInfoCard" style = "display: flex; flex-direction:column;" width="30%" height="40%" min-width="23em">
           <v-card-title :class = "['card-header',courseColor(currentSubject.subject_id)]">
             <v-flex style = "display: flex; flex-direction: row; align-items: center;">
               <div style = "padding: 0; margin: 0; display: block;">


### PR DESCRIPTION
This PR finishes the last of the style changes we wanted to make on the `ClassInfo` component. It:
- Adds a link to access course evaluations on the course rating
- Resizes the `v-card` to be larger
- Uses hardcoded `CSS` to align the `v-card` with the search rather than using `JavaScript` to calculate the position each time

I'm not sure how the new `v-card` sizes look due to the fact that my screen is 4K and it could look worse on other systems. We might have to mess with that a bit before merging.

This PR closes #64.