### PR TITLE
Icon things

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -102,6 +102,7 @@
             v-bind:subjectIndex = "subjectsIndexDict"
             v-bind:genericCourses = "genericCourses"
             v-bind:genericIndex = "genericIndexDict"
+            v-bind:progressOverrides = "roads[activeRoad].contents.progressOverrides"
             @drag-start-class = "dragStartClass"
             @add-req = "addReq"
             @remove-req = "removeReq"

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -12,7 +12,11 @@
       <!-- TODO: useful icons can go here if you can figure out how -->
       <template slot="prepend" slot-scope="{ item, leaf, open }">
         <v-icon v-if = "!('reqs' in item)" :style = "fulfilledIcon(item)">
-          {{ item['plain-string'] ? item.fulfilled ? "assignment_turned_in" : "assignment": item.fulfilled ? "done" : "remove"}}
+          {{ item['plain-string'] ?
+          (item["list-id"] in progressOverrides ?
+            (item.fulfilled ? "assignment_turned_in" : "assignment") :
+            "assignment_late" ) :
+          item.fulfilled ? "done" : "remove"}}
         </v-icon>
       </template>
       <template slot = "label" slot-scope = "{ item, leaf}">
@@ -91,7 +95,7 @@ export default {
   components: {
     'requirement': Requirement,
   },
-  props: ['selectedReqs', 'reqTrees', 'reqList', 'subjects', 'genericCourses', 'subjectIndex', 'genericIndex'],
+  props: ['selectedReqs', 'reqTrees', 'reqList', 'subjects', 'genericCourses', 'subjectIndex', 'genericIndex', 'progressOverrides'],
   data: function() { return {
     tree: [],
     viewDialog: false,

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -17,7 +17,7 @@
               <!-- {{ open ? 'assignment_returned' : item.fulfilled ? 'assignment_turned_in' : 'assignment' }} -->
             </v-icon>
             <v-icon v-else :style = "fulfilledIcon(item)">
-              {{ item['plain-string'] ? item.fulfilled ? "star" : "star_outline": item.fulfilled ? "check_box" : "check_box_outline_blank"}}
+              {{ item['plain-string'] ? item.fulfilled ? "assignment_turned_in" : "assignment": item.fulfilled ? "done" : "remove"}}
             </v-icon>
           </template>
           <span>{{item.percent_fulfilled}}%</span>

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -11,7 +11,7 @@
     >
       <!-- TODO: useful icons can go here if you can figure out how -->
       <template slot="prepend" slot-scope="{ item, leaf, open }">
-        <v-tooltip left>
+        <v-tooltip left  @click.native = "clickRequirement(item)">
           <template slot = "activator">
             <v-icon v-if="'reqs' in item" :style = "fulfilledIcon(item)">
               <!-- {{ open ? 'assignment_returned' : item.fulfilled ? 'assignment_turned_in' : 'assignment' }} -->
@@ -32,7 +32,7 @@
           v-bind:genericCourses = "genericCourses"
           v-bind:genericIndex = "genericIndex"
           @drag-start-class = "$emit('drag-start-class',$event)"
-          @push-stack = "$emit('push-stack',$event)"
+           @click.native = "clickRequirement(item)"
         >
         </requirement>
       </template>
@@ -147,7 +147,16 @@ export default {
     deleteReq: function(req) {
       var reqName = req["list-id"].substring(0, req["list-id"].indexOf(".reql"));
       this.$emit("remove-req",reqName);
-    }
+    },
+    clickRequirement: function(item) {
+      if(item.req !== undefined) {
+        var usedReq = item.req;
+        if(usedReq.indexOf("GIR:")===0) {
+          usedReq = usedReq.substring(4);
+        }
+        this.$emit('push-stack', usedReq);
+      }
+    },
   },
 
 }

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -11,7 +11,7 @@
     >
       <!-- TODO: useful icons can go here if you can figure out how -->
       <template slot="prepend" slot-scope="{ item, leaf, open }">
-        <v-icon v-if = "!('reqs' in item)" :style = "fulfilledIcon(item)">
+        <v-icon v-if = "!('reqs' in item)" :style = "fulfilledIcon(item)" @click = "clickRequirement(item)">
           {{ item['plain-string'] ?
           (item["list-id"] in progressOverrides ?
             (item.fulfilled ? "assignment_turned_in" : "assignment") :

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -32,12 +32,10 @@
           v-bind:genericCourses = "genericCourses"
           v-bind:genericIndex = "genericIndex"
           @drag-start-class = "$emit('drag-start-class',$event)"
-           @click.native = "clickRequirement(item)"
+          @click.native = "clickRequirement(item)"
+          @click-info = "reqInfo($event, item)"
         >
         </requirement>
-      </template>
-      <template slot = "append" slot-scope = "{ item, leaf }">
-        <v-btn v-if="'reqs' in item" icon flat color = "info" @click.stop = "reqInfo($event, item)"><v-icon>info</v-icon></v-btn>
       </template>
     </v-treeview>
 

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -11,17 +11,9 @@
     >
       <!-- TODO: useful icons can go here if you can figure out how -->
       <template slot="prepend" slot-scope="{ item, leaf, open }">
-        <v-tooltip left  @click.native = "clickRequirement(item)">
-          <template slot = "activator">
-            <v-icon v-if="'reqs' in item" :style = "fulfilledIcon(item)">
-              <!-- {{ open ? 'assignment_returned' : item.fulfilled ? 'assignment_turned_in' : 'assignment' }} -->
-            </v-icon>
-            <v-icon v-else :style = "fulfilledIcon(item)">
-              {{ item['plain-string'] ? item.fulfilled ? "assignment_turned_in" : "assignment": item.fulfilled ? "done" : "remove"}}
-            </v-icon>
-          </template>
-          <span>{{item.percent_fulfilled}}%</span>
-        </v-tooltip>
+        <v-icon v-if = "!('reqs' in item)" :style = "fulfilledIcon(item)">
+          {{ item['plain-string'] ? item.fulfilled ? "assignment_turned_in" : "assignment": item.fulfilled ? "done" : "remove"}}
+        </v-icon>
       </template>
       <template slot = "label" slot-scope = "{ item, leaf}">
         <requirement

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -9,14 +9,13 @@
       open-on-click
       :activatable = "false"
     >
-      <!-- TODO: useful icons can go here if you can figure out how -->
       <template slot="prepend" slot-scope="{ item, leaf, open }">
         <v-icon v-if = "!('reqs' in item)" :style = "fulfilledIcon(item)" @click = "clickRequirement(item)">
           {{ item['plain-string'] ?
-          (item["list-id"] in progressOverrides ?
-            (item.fulfilled ? "assignment_turned_in" : "assignment") :
-            "assignment_late" ) :
-          item.fulfilled ? "done" : "remove"}}
+              (item["list-id"] in progressOverrides ?
+                  (item.fulfilled ? "assignment_turned_in" : "assignment") :
+                  "assignment_late" ) :
+              item.fulfilled ? "done" : "remove"}}
         </v-icon>
       </template>
       <template slot = "label" slot-scope = "{ item, leaf}">

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -51,7 +51,7 @@
         </v-card-text>
         <v-card-text v-if = "'desc' in dialogReq">{{dialogReq["desc"]}}</v-card-text>
         <v-card-text>
-          <div class = "percentage-bar" :style = "percentage(dialogReq)">
+          <div class = "percentage-bar p-block" :style = "percentage(dialogReq)">
             {{dialogReq["percent_fulfilled"]}}% fulfilled
           </div>
         </v-card-text>
@@ -140,8 +140,9 @@ export default {
       this.dialogReq = req;
     },
     percentage: function(req) {
-      var pfulfilled = req.percent_fulfilled
-      var pstring = "--percent: " + req.percent_fulfilled+"%";
+      var pfulfilled = req.percent_fulfilled;
+      var pcolor = req.fulfilled ? "#00b300" : (req.percent_fulfilled > 15 ? "#efce15": "#ef8214");
+      var pstring = "--percent: " + pfulfilled +"%; --bar-color: " + pcolor + "; --bg-color: #ffffff";
       return pstring;
     },
     deleteReq: function(req) {
@@ -162,10 +163,13 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
+
 .percentage-bar {
+  background: linear-gradient(90deg, var(--bar-color) var(--percent), var(--bg-color) var(--percent));
+}
+.p-block{
   height: 30px;
-  background: linear-gradient(90deg, #00b300 var(--percent), rgba(255,255,255,0) var(--percent));
   border: 1px solid gray;
   padding-left: 5px;
   padding-top: 5px;

--- a/src/components/Class.vue
+++ b/src/components/Class.vue
@@ -36,6 +36,7 @@
     </v-hover>
     <v-dialog v-model = "warningDialog">
       <v-card>
+        <v-btn icon flat style = "float:right" @click = "warningDialog = false"><v-icon>close</v-icon></v-btn>
         <v-card-title>
           <h3>Warnings for {{classInfo.id}}</h3>
         </v-card-title>

--- a/src/components/ConflictDialog.vue
+++ b/src/components/ConflictDialog.vue
@@ -1,6 +1,7 @@
 <template>
   <v-dialog v-model = "conflictDialog" v-if = "conflictInfo != undefined">
     <v-card>
+      <v-btn icon flat style = "float:right" @click = "conflictDialog = false"><v-icon>close</v-icon></v-btn>
       <v-card-title>Save Conflict</v-card-title>
       <v-layout row>
         <v-flex xs6 style = "padding: 2em">

--- a/src/components/ImportExport.vue
+++ b/src/components/ImportExport.vue
@@ -17,7 +17,10 @@
           class="headline grey lighten-2"
           primary-title
         >
-          Import Road
+            Import Road
+            <v-flex align-end>
+              <v-btn icon flat style = "float:right;" @click = "dialog = false"><v-icon>close</v-icon></v-btn>
+            </v-flex>
         </v-card-title>
 
         <v-card-text>

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -8,34 +8,36 @@
   >
   <v-layout row>
     <v-flex>
-      <div v-if="!leaf">
-        <span v-if="'title-no-degree' in req && req['title-no-degree'] !=''">{{ req["title-no-degree"] }}</span>
-        <span v-else-if = "'short-title' in req && req['short-title'] != ''">{{ req['short-title']}}</span>
-        <span v-else-if = "'title' in req">{{ req["title"] }}</span>
-        <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
-        <!--fake padding for scroll-->
-        &nbsp &nbsp &nbsp
-      </div>
-      <span v-else>
-        <span v-if="'title' in req">{{ req.title }}</span>
-      </span>
-
-      <span v-if = "!req['plain-string']">
-        <span v-if="!('title' in req) && 'req' in req">
-          <span :class="reqFulfilled">{{ req.req }}</span>
-          <span style = "font-style:italic" v-if = "'threshold-desc' in req">({{ req['threshold-desc']}})</span>
+      <div>
+        <div v-if="!leaf" style = "display: inline;">
+          <span v-if="'title-no-degree' in req && req['title-no-degree'] !=''">{{ req["title-no-degree"] }}</span>
+          <span v-else-if = "'short-title' in req && req['short-title'] != ''">{{ req['short-title']}}</span>
+          <span v-else-if = "'title' in req">{{ req["title"] }}</span>
+          <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
+          <!--fake padding for scroll-->
+          &nbsp &nbsp &nbsp
+        </div>
+        <span v-else>
+          <span v-if="'title' in req">{{ req.title }}</span>
         </span>
-      </span>
-      <span v-else>
-        <span v-if = "'title' in req">| </span>
-        <span style = "text-transform: cursive">{{ req.req }}</span>
-      </span>
-      <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
-         (optional)
-      </span>
-      <div :class = "percentage_bar" :style = "percentage"></div>
+        <span v-if = "!req['plain-string']">
+          <span v-if="!('title' in req) && 'req' in req">
+            <span :class="reqFulfilled">{{ req.req }}</span>
+            <span style = "font-style:italic" v-if = "'threshold-desc' in req">({{ req['threshold-desc']}})</span>
+          </span>
+        </span>
+        <span v-else>
+          <span v-if = "'title' in req">| </span>
+          <span style = "text-transform: cursive">{{ req.req }}</span>
+        </span>
+        <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
+           (optional)
+        </span>
+        <span v-if = "hoveringOver && ('reqs' in req || 'threshold' in req) && 'percent_fulfilled' in req && req.percent_fulfilled !== 'N/A'":style = "'float: right; color: '+percentageTextColor">{{req.percent_fulfilled}}%</span>
+        <div :class = "percentage_bar" :style = "percentage"></div>
+      </div>
     </v-flex>
-    <v-icon v-if = "'reqs' in req && hoveringOver" @mouseover = "iconHover = true" @mouseleave = "iconHover = false" @click.stop = "$emit('click-info', $event)" small :color = "iconColor">info</v-icon>
+    <v-icon style = "padding-left: 0.2em; padding-right: 0em;" v-if = "'reqs' in req && hoveringOver" @mouseover = "iconHover = true" @mouseleave = "iconHover = false" @click.stop = "$emit('click-info', $event)" small :color = "iconColor">info</v-icon>
   </v-layout>
   </div>
 
@@ -86,10 +88,15 @@ export default {
         }
       }
     },
+    percentageTextColor: function() {
+      return this.req.fulfilled ? "#008400": (this.req.percent_fulfilled > 15 ? "#d1b82b": "#d3701f");
+    },
+    percentageColor: function() {
+      return this.req.fulfilled ? "#00b300" : (this.req.percent_fulfilled > 15 ? "#efce15": "#ef8214");
+    },
     percentage: function() {
       var pfulfilled = this.req.percent_fulfilled;
-      var pcolor = this.req.fulfilled ? "#00b300" : (this.req.percent_fulfilled > 15 ? "#efce15": "#ef8214");
-      var pstring = "--percent: " + pfulfilled +"%; --bar-color: " + pcolor + "; --bg-color: lightgrey";
+      var pstring = "--percent: " + pfulfilled +"%; --bar-color: " + this.percentageColor + "; --bg-color: lightgrey";
       return pstring;
     },
     percentage_bar: function() {

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -77,13 +77,16 @@ export default {
       }
     },
     percentage: function() {
-      var pfulfilled = this.req.percent_fulfilled
-      var pstring = "--percent: "+this.req.percent_fulfilled+"%";
+      var pfulfilled = this.req.percent_fulfilled;
+      var pcolor = this.req.fulfilled ? "#00b300" : (this.req.percent_fulfilled > 15 ? "#efce15": "#ef8214");
+      var pstring = "--percent: " + pfulfilled +"%; --bar-color: " + pcolor + "; --bg-color: lightgrey";
       return pstring;
     },
     percentage_bar: function() {
+      var showPBar = ("reqs" in this.req || "threshold" in this.req);
       var pblock = {
-        "percentage-bar": ("reqs" in this.req || "threshold" in this.req)
+        "percentage-bar": showPBar,
+        "p-bar": showPBar
       }
       return pblock
     }
@@ -114,8 +117,7 @@ export default {
     font-size: 0.75em;
   }
 
-  .percentage-bar {
+  .p-bar {
     height: 4px;
-    background: linear-gradient(90deg, #00b300 var(--percent), lightgrey var(--percent));
   }
 </style>

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -15,7 +15,6 @@
           <span v-else-if = "'title' in req">{{ req["title"] }}</span>
           <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
           <!--fake padding for scroll-->
-          &nbsp
         </div>
         <span v-else>
           <span v-if="'title' in req">{{ req.title }}</span>
@@ -33,6 +32,7 @@
         <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
            (optional)
         </span>
+        <span v-if = "!leaf || req['plain-string'] !== undefined">&nbsp</span>
         <span v-if = "hoveringOver && ('reqs' in req || 'threshold' in req) && 'percent_fulfilled' in req && req.percent_fulfilled !== 'N/A'":style = "'float: right; color: '+percentageTextColor">{{req.percent_fulfilled}}%</span>
         <div :class = "percentage_bar" :style = "percentage"></div>
       </div>

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -8,33 +8,31 @@
 >
   <v-layout row>
     <v-flex>
-      <div>
-        <div v-if="!leaf" style = "display: inline;">
-          <span v-if="'title-no-degree' in req && req['title-no-degree'] !=''">{{ req["title-no-degree"] }}</span>
-          <span v-else-if = "'short-title' in req && req['short-title'] != ''">{{ req['short-title']}}</span>
-          <span v-else-if = "'title' in req">{{ req["title"] }}</span>
-          <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
-        </div>
-        <span v-else>
-          <span v-if="'title' in req">{{ req.title }}</span>
-        </span>
-        <span v-if = "!req['plain-string']">
-          <span v-if="!('title' in req) && 'req' in req">
-            <span :class="reqFulfilled">{{ req.req }}</span>
-            <span style = "font-style:italic" v-if = "'threshold-desc' in req">({{ req['threshold-desc']}})</span>
-          </span>
-        </span>
-        <span v-else>
-          <span v-if = "'title' in req">| </span>
-          <span style = "text-transform: cursive">{{ req.req }}</span>
-        </span>
-        <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
-           (optional)
-        </span>
-        <span v-if = "'req' in req || 'threshold' in req">&nbsp</span>
-        <span v-if = "hoveringOver && ('reqs' in req || 'threshold' in req) && 'percent_fulfilled' in req && req.percent_fulfilled !== 'N/A'":style = "'float: right; color: '+percentageTextColor">{{req.percent_fulfilled}}%</span>
-        <div :class = "percentage_bar" :style = "percentage"></div>
+      <div v-if="!leaf" style = "display: inline;">
+        <span v-if="'title-no-degree' in req && req['title-no-degree'] !=''">{{ req["title-no-degree"] }}</span>
+        <span v-else-if = "'short-title' in req && req['short-title'] != ''">{{ req['short-title']}}</span>
+        <span v-else-if = "'title' in req">{{ req["title"] }}</span>
+        <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
       </div>
+      <span v-else>
+        <span v-if="'title' in req">{{ req.title }}</span>
+      </span>
+      <span v-if = "!req['plain-string']">
+        <span v-if="!('title' in req) && 'req' in req">
+          <span :class="reqFulfilled">{{ req.req }}</span>
+          <span style = "font-style:italic" v-if = "'threshold-desc' in req">({{ req['threshold-desc']}})</span>
+        </span>
+      </span>
+      <span v-else>
+        <span v-if = "'title' in req">| </span>
+        <span style = "text-transform: cursive">{{ req.req }}</span>
+      </span>
+      <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
+         (optional)
+      </span>
+      <span v-if = "'req' in req || 'threshold' in req">&nbsp</span>
+      <span v-if = "hoveringOver && ('reqs' in req || 'threshold' in req) && 'percent_fulfilled' in req && req.percent_fulfilled !== 'N/A'":style = "'float: right; color: '+percentageTextColor">{{req.percent_fulfilled}}%</span>
+      <div :class = "percentage_bar" :style = "percentage"></div>
     </v-flex>
     <v-icon style = "padding-left: 0.2em; padding-right: 0em;" v-if = "'reqs' in req && hoveringOver" @mouseover = "iconHover = true" @mouseleave = "iconHover = false" @click.stop = "$emit('click-info', $event)" small :color = "iconColor">info</v-icon>
   </v-layout>

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -15,7 +15,7 @@
           <span v-else-if = "'title' in req">{{ req["title"] }}</span>
           <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
           <!--fake padding for scroll-->
-          &nbsp &nbsp &nbsp
+          &nbsp
         </div>
         <span v-else>
           <span v-if="'title' in req">{{ req.title }}</span>

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -32,7 +32,7 @@
         <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
            (optional)
         </span>
-        <span v-if = "!leaf || req['plain-string'] !== undefined">&nbsp</span>
+        <span v-if = "'req' in req || 'threshold' in req">&nbsp</span>
         <span v-if = "hoveringOver && ('reqs' in req || 'threshold' in req) && 'percent_fulfilled' in req && req.percent_fulfilled !== 'N/A'":style = "'float: right; color: '+percentageTextColor">{{req.percent_fulfilled}}%</span>
         <div :class = "percentage_bar" :style = "percentage"></div>
       </div>

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -3,35 +3,43 @@
     class = "requirement"
     :draggable = "canDrag"
     v-on:dragstart = "dragStart"
+    @mouseover = "hoveringOver = true"
+    @mouseleave = "hoveringOver = false"
   >
-    <div v-if="!leaf">
-      <span v-if="'title-no-degree' in req && req['title-no-degree'] !=''">{{ req["title-no-degree"] }}</span>
-      <span v-else-if = "'short-title' in req && req['short-title'] != ''">{{ req['short-title']}}</span>
-      <span v-else-if = "'title' in req">{{ req["title"] }}</span>
-      <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
-      <!--fake padding for scroll-->
-      &nbsp &nbsp &nbsp
-      <v-btn icon flat fixed v-if = "showDelete" @click = "viewDialog = true;"><v-icon>delete</v-icon></v-btn>
-    </div>
-    <span v-else>
-      <span v-if="'title' in req">{{ req.title }}</span>
-    </span>
-
-    <span v-if = "!req['plain-string']">
-      <span v-if="!('title' in req) && 'req' in req">
-        <span :class="reqFulfilled">{{ req.req }}</span>
-        <span style = "font-style:italic" v-if = "'threshold-desc' in req">({{ req['threshold-desc']}})</span>
+  <v-layout row>
+    <v-flex>
+      <div v-if="!leaf">
+        <span v-if="'title-no-degree' in req && req['title-no-degree'] !=''">{{ req["title-no-degree"] }}</span>
+        <span v-else-if = "'short-title' in req && req['short-title'] != ''">{{ req['short-title']}}</span>
+        <span v-else-if = "'title' in req">{{ req["title"] }}</span>
+        <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
+        <!--fake padding for scroll-->
+        &nbsp &nbsp &nbsp
+        <v-btn icon flat fixed v-if = "showDelete" @click = "viewDialog = true;"><v-icon>delete</v-icon></v-btn>
+      </div>
+      <span v-else>
+        <span v-if="'title' in req">{{ req.title }}</span>
       </span>
-    </span>
-    <span v-else>
-      <span v-if = "'title' in req">| </span>
-      <span style = "text-transform: cursive">{{ req.req }}</span>
-    </span>
-    <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
-       (optional)
-    </span>
-    <div :class = "percentage_bar" :style = "percentage"></div>
+
+      <span v-if = "!req['plain-string']">
+        <span v-if="!('title' in req) && 'req' in req">
+          <span :class="reqFulfilled">{{ req.req }}</span>
+          <span style = "font-style:italic" v-if = "'threshold-desc' in req">({{ req['threshold-desc']}})</span>
+        </span>
+      </span>
+      <span v-else>
+        <span v-if = "'title' in req">| </span>
+        <span style = "text-transform: cursive">{{ req.req }}</span>
+      </span>
+      <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
+         (optional)
+      </span>
+      <div :class = "percentage_bar" :style = "percentage"></div>
+    </v-flex>
+    <v-icon @mouseover = "iconHover = true" @mouseleave = "iconHover = false" @click.stop = "$emit('click-info', $event)" v-if = "hoveringOver" small :color = "iconClass">info</v-icon>
+  </v-layout>
   </div>
+
 </template>
 
 
@@ -43,7 +51,9 @@ export default {
     return {
       open: [],
       viewDialog: false,
-      showDelete: false
+      showDelete: false,
+      hoveringOver: false,
+      iconHover: false,
     }
   },
   computed: {
@@ -61,6 +71,9 @@ export default {
         }
       }
       return undefined;
+    },
+    iconClass: function() {
+      return this.iconHover ? "info" : "grey";
     },
     canDrag: function() {
       return this.classInfo !== undefined || ('req' in this.req && (Object.keys(this.subjectIndex).length===0));

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -1,11 +1,11 @@
 <template>
-  <div
-    class = "requirement"
-    :draggable = "canDrag"
-    v-on:dragstart = "dragStart"
-    @mouseover = "hoveringOver = true"
-    @mouseleave = "hoveringOver = false"
-  >
+<div
+  class = "requirement"
+  :draggable = "canDrag"
+  v-on:dragstart = "dragStart"
+  @mouseover = "hoveringOver = true"
+  @mouseleave = "hoveringOver = false"
+>
   <v-layout row>
     <v-flex>
       <div>
@@ -14,7 +14,6 @@
           <span v-else-if = "'short-title' in req && req['short-title'] != ''">{{ req['short-title']}}</span>
           <span v-else-if = "'title' in req">{{ req["title"] }}</span>
           <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
-          <!--fake padding for scroll-->
         </div>
         <span v-else>
           <span v-if="'title' in req">{{ req.title }}</span>
@@ -39,8 +38,7 @@
     </v-flex>
     <v-icon style = "padding-left: 0.2em; padding-right: 0em;" v-if = "'reqs' in req && hoveringOver" @mouseover = "iconHover = true" @mouseleave = "iconHover = false" @click.stop = "$emit('click-info', $event)" small :color = "iconColor">info</v-icon>
   </v-layout>
-  </div>
-
+</div>
 </template>
 
 

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -35,7 +35,7 @@
       </span>
       <div :class = "percentage_bar" :style = "percentage"></div>
     </v-flex>
-    <v-icon @mouseover = "iconHover = true" @mouseleave = "iconHover = false" @click.stop = "$emit('click-info', $event)" v-if = "hoveringOver" small :color = "iconClass">info</v-icon>
+    <v-icon v-if = "'reqs' in req && hoveringOver" @mouseover = "iconHover = true" @mouseleave = "iconHover = false" @click.stop = "$emit('click-info', $event)" small :color = "iconColor">info</v-icon>
   </v-layout>
   </div>
 
@@ -69,7 +69,7 @@ export default {
       }
       return undefined;
     },
-    iconClass: function() {
+    iconColor: function() {
       return this.iconHover ? "info" : "grey";
     },
     canDrag: function() {

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -3,7 +3,6 @@
     class = "requirement"
     :draggable = "canDrag"
     v-on:dragstart = "dragStart"
-    @click = "clickRequirement"
   >
     <div v-if="!leaf">
       <span v-if="'title-no-degree' in req && req['title-no-degree'] !=''">{{ req["title-no-degree"] }}</span>
@@ -90,15 +89,6 @@ export default {
     }
   },
   methods: {
-    clickRequirement: function(event) {
-      if(this.req.req !== undefined) {
-        var usedReq = this.req.req;
-        if(usedReq.indexOf("GIR:")===0) {
-          usedReq = usedReq.substring(4);
-        }
-        this.$emit('push-stack', usedReq);
-      }
-    },
     dragStart: function(event) {
       var usedInfo = this.classInfo;
       if(usedInfo === undefined) {

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -15,7 +15,6 @@
         <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
         <!--fake padding for scroll-->
         &nbsp &nbsp &nbsp
-        <v-btn icon flat fixed v-if = "showDelete" @click = "viewDialog = true;"><v-icon>delete</v-icon></v-btn>
       </div>
       <span v-else>
         <span v-if="'title' in req">{{ req.title }}</span>
@@ -50,8 +49,6 @@ export default {
   data: function() {
     return {
       open: [],
-      viewDialog: false,
-      showDelete: false,
       hoveringOver: false,
       iconHover: false,
     }

--- a/src/components/Road.vue
+++ b/src/components/Road.vue
@@ -35,7 +35,10 @@
     </semester>
     <v-dialog v-model = "changeYearDialog">
       <v-card>
-        <v-card-title>Change Class Year</v-card-title>
+        <v-btn icon flat style = "float:right" @click = "changeYearDialog = false"><v-icon>close</v-icon></v-btn>
+        <v-card-title>
+          Change Class Year
+        </v-card-title>
         <v-card-text>
           <v-select
             v-model = "newYear"

--- a/src/components/RoadTabs.vue
+++ b/src/components/RoadTabs.vue
@@ -18,6 +18,7 @@
       </v-tab>
       <v-dialog v-model = "editDialog" @input = "newRoadName = ''">
         <v-card style = "padding: 2em">
+          <v-btn icon flat style = "float:right" @click = "editDialog = false"><v-icon>close</v-icon></v-btn>
           <v-card-title>Edit Road</v-card-title>
           <v-text-field v-model = "newRoadName" label = "Road Name"></v-text-field>
           <v-card-actions>
@@ -31,6 +32,7 @@
       </v-dialog>
       <v-dialog v-model = "deleteDialog" v-if = "tabRoad in roads">
         <v-card style = "padding: 2em">
+          <v-btn icon flat style = "float:right" @click = "deleteDialog = false"><v-icon>close</v-icon></v-btn>
           <v-card-title>Permanently Delete {{roads[tabRoad].name}}?</v-card-title>
           <v-card-text>This action cannot be undone.</v-card-text>
           <v-card-actions>
@@ -41,6 +43,7 @@
       </v-dialog>
       <v-dialog v-model = "addDialog" width = "500" @input = "newRoadName = ''">
         <v-card style = "padding: 2em">
+          <v-btn icon flat style = "float:right" @click = "addDialog = false"><v-icon>close</v-icon></v-btn>
           <v-card-title>Create Road</v-card-title>
           <v-text-field v-model = "newRoadName"></v-text-field>
           <v-layout row>


### PR DESCRIPTION
Closes #141 

Changes from description in #141:
-Added an orange color in addition to yellow on the progress bar (<15% complete)
-Can't access the dropdown icons, so instead of the tooltips, the percentage now displays next to the info icon (open to suggestions on better ways of displaying this, but I think it looks nice)

Also an idea that came up during this process was to make the icon buttons black then fade to grey when they appear to draw attention to them.  Could make an issue for backburner if this is a good idea.