### PR TITLE
fix progress overrides

### DIFF
--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -149,6 +149,7 @@ export default {
               if(roadData[r].data.file.contents.progressOverrides === undefined) {
                 roadData[r].data.file.contents.progressOverrides = {};
               }
+              // sanitize subject_id
               let newss = roadData[r].data.file.contents.selectedSubjects.map((s) => {
                 if ('subject_id' in s) {
                   s.id = s.subject_id
@@ -157,6 +158,11 @@ export default {
                 return s
               });
               roadData[r].data.file.contents.selectedSubjects = newss
+              // sanitize progressOverrides
+              if (roadData[r].data.file.contents.progressOverrides === undefined){
+                roadData[r].data.file.contents.progressOverrides = {}
+              }
+              
               this.$emit("set-road", roadIDs[r], roadData[r].data.file);
             }
           }

--- a/src/components/ImportExport.vue
+++ b/src/components/ImportExport.vue
@@ -115,6 +115,11 @@ export default {
           // parse text and add to roads
           var obj = JSON.parse(this.inputtext);
           // sanitize
+          // progressOverrides must be defined
+          if (obj.progressOverrides === undefined){
+            obj.progressOverrides = {}
+          }
+          // subject_id issue
           let newss = obj.selectedSubjects.map((s) => {
             if ('subject_id' in s) {
               s.id = s.subject_id
@@ -150,7 +155,7 @@ export default {
           }).filter((s) => {
             return s !== undefined;
           })
-          this.$emit('add-road', this.roadtitle, obj.coursesOfStudy, ss)
+          this.$emit('add-road', this.roadtitle, obj.coursesOfStudy, ss, obj.progressOverrides)
         } catch(error) {
           fail = true;
           console.log('import failed with error:')

--- a/src/components/RoadTabs.vue
+++ b/src/components/RoadTabs.vue
@@ -123,7 +123,12 @@ export default {
       if(!this.duplicateRoad) {
         this.$emit('add-road', this.newRoadName);
       } else if(this.duplicateRoadSource in this.roads){
-        this.$emit('add-road', this.newRoadName, this.roads[this.duplicateRoadSource].contents.coursesOfStudy.slice(0), this.roads[this.duplicateRoadSource].contents.selectedSubjects.slice(0));
+        this.$emit('add-road',
+            this.newRoadName,
+            this.roads[this.duplicateRoadSource].contents.coursesOfStudy.slice(0),
+            this.roads[this.duplicateRoadSource].contents.selectedSubjects.slice(0),
+            Object.assign({}, this.roads[this.duplicateRoadSource].contents.progressOverrides),
+        );
       }
       this.addDialog=false;
       this.newRoadName = ''

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -43,7 +43,7 @@
         v-bind:subjectsIndex = "subjectsIndexDict"
         v-bind:genericCourses = "genericCourses"
         v-bind:genericIndex = "genericIndexDict"
-        @add-road = "addRoad"
+        @add-road = "addRoad(...arguments)"
       >
       </import-export>
 
@@ -408,11 +408,12 @@ export default {
       window.location.hash = "#/#road" + this.activeRoad;
       return false;
     },
-    addRoad: function(roadName, cos=["girs"], ss=[]) {
+    addRoad: function(roadName, cos=["girs"], ss=[], overrides={}) {
       var tempRoadID = "$" + this.$refs.authcomponent.newRoads.length + "$";
       var newContents = {
           coursesOfStudy: cos,
           selectedSubjects: ss,
+          progressOverrides: overrides,
         }
       var newRoad = {
         downloaded: moment().format(DATE_FORMAT),


### PR DESCRIPTION
it didn't always exist. also turns out we were copying them or importing them.

With these changes they are both copied and imported, and `progressOverrides` is always added to new roads if it didn't already exist.