### PR TITLE
switch to fireroad.mit.edu on /dev/

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "test",
-    "build-dev": "webpack --env.APP_URL=https://courseroad.mit.edu/dev --env.FIREROAD_URL=https://fireroad-dev.mit.edu --mode=production --config build/webpack.config.dev.js",
+    "build-dev": "webpack --env.APP_URL=https://courseroad.mit.edu/dev --env.FIREROAD_URL=https://fireroad.mit.edu --mode=production --config build/webpack.config.dev.js",
     "build-prod": "webpack --env.APP_URL=https://courseroad.mit.edu --env.FIREROAD_URL=https://fireroad.mit.edu --mode=production --config build/webpack.config.dev.js",
     "dev": "webpack-dev-server --env.APP_URL=http://localhost:8080 --env.FIREROAD_URL=https://fireroad-dev.mit.edu --mode=development --config build/webpack.config.dev.js"
   },


### PR DESCRIPTION
I need a place to test production-mode changes without breaking the main site. That's what /dev/ was supposed to be for anyways.